### PR TITLE
fix: improve UI text and styling

### DIFF
--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -10,8 +10,8 @@ const HomePage = () => {
     <>
     <section className='card-cta'>
       <div className='flex flex-col gap-6 max-w-lg'>
-        <h2>Get Interview Ready with AI-Powered Practise & Feedback</h2>
-        <p className='text-lg'>Practise on real interview questions and get instant feedback</p>
+        <h2>Get Interview Ready with AI-Powered Practice & Feedback</h2>
+        <p className='text-lg'>Practice on real interview questions and get instant feedback</p>
         <Button asChild className='btn-primary max-sm:w-full'>
           <Link href='/interview'>Start an Interview</Link>
         </Button>

--- a/components/Agent.tsx
+++ b/components/Agent.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 import React from 'react'
-import { cn } from '@/lib/utils' // Add this import for cn function
+import { cn } from '@/lib/utils' // Utility for conditional class names
 
 enum CallStatus {
     INACTIVE = 'INACTIVE',

--- a/components/InterviewCard.tsx
+++ b/components/InterviewCard.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 import DisplayTechIcons from './DisplayTechIcons';
 
 
-const InterviewCard = ({interviewId, userId, role, type, techstack, createdAt} : InterviewCardProps) => {
+const InterviewCard = ({interviewId, role, type, techstack, createdAt} : InterviewCardProps) => {
   const feedback = null as Feedback | null
   const normalizedType = /mix/gi.test(type) ? 'Mixed' : type;
   const formattedDate = dayjs(feedback?.createdAt || createdAt || Date.now()).format('MMM D, YYYY')
@@ -18,7 +18,7 @@ const InterviewCard = ({interviewId, userId, role, type, techstack, createdAt} :
                 <div className='absolute top-0 right-0 w-fit px-4 py-2 rounded-bl-lg bg-light-600'>
                     <p className='badge-text'>{normalizedType}</p>
                 </div>
-                <Image alt='cover image' src={getRandomInterviewCover()} width={90} height={90} className='rounded-full object-fit size-[90px]'></Image>
+                <Image alt='cover image' src={getRandomInterviewCover()} width={90} height={90} className='rounded-full object-cover size-[90px]'></Image>
             <h3 className='mt-5 capitalize'>{role} Interview</h3>
             <div className='flex flex-row gap-5 mt-3'>
                 <div className='flex flex-row gap-2'>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,7 +40,6 @@ interface User {
 
 interface InterviewCardProps {
   interviewId?: string;
-  userId?: string;
   role: string;
   type: string;
   techstack: string[];


### PR DESCRIPTION
## Summary
- correct "Practice" spelling on homepage hero text
- replace invalid `object-fit` class with `object-cover`
- clarify `cn` utility comment and remove unused `userId` prop

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and unused vars in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68951cc009a88325a6c947bd55141a85