### PR TITLE
Remove unused user props from interview page

### DIFF
--- a/app/interview/page.tsx
+++ b/app/interview/page.tsx
@@ -6,7 +6,7 @@ const Interview = () => {
    <>
    <div className='root-layout'>
     <h3>Interview Generation</h3>
-    <Agent userName="You" userId="user1" type="generate"></Agent>
+    <Agent userName="You" />
    </div>
    </>
   )


### PR DESCRIPTION
## Summary
- remove `userId` and `type` props from interview page to match `Agent` component props

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68963a7e35308325b2db3635630ae085