### PR TITLE
Verify Vapi token before initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Environment Variables
+
+This project expects a Vapi token to be available at build time. Create a `.env.local` file in the project root and define:
+
+```env
+NEXT_PUBLIC_VAPI_WEB_TOKEN=your_vapi_token_here
+```
+
+The application will throw an error on startup if this variable is missing.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/lib/vapi.sdk.ts
+++ b/lib/vapi.sdk.ts
@@ -1,4 +1,10 @@
 import Vapi from '@vapi-ai/web'
 
-export const vapi = new Vapi(process.env.NEXT_PUBLIC_VAPI_WEB_TOKEN!)
+const token = process.env.NEXT_PUBLIC_VAPI_WEB_TOKEN
+
+if (!token) {
+  throw new Error('NEXT_PUBLIC_VAPI_WEB_TOKEN is not set. Please add your Vapi token to the environment.')
+}
+
+export const vapi = new Vapi(token)
 


### PR DESCRIPTION
## Summary
- add runtime check for `NEXT_PUBLIC_VAPI_WEB_TOKEN` before creating Vapi instance
- document required Vapi token environment variable in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_68963a7ea6ec8325b1521f3e537a85d9