### PR TITLE
Remove debug logs and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 
 ## Environment Variables
 
-This project expects a Vapi token to be available at build time. Create a `.env.local` file in the project root and define:
+This project expects a Vapi token and assistant ID to be available at build time. Create a `.env.local` file in the project root and define:
 
 ```env
 NEXT_PUBLIC_VAPI_WEB_TOKEN=your_vapi_token_here
+NEXT_PUBLIC_VAPI_ASSISTANT_ID=your_vapi_assistant_id_here
 ```
 
-The application will throw an error on startup if this variable is missing.
+The application will throw an error on startup if `NEXT_PUBLIC_VAPI_WEB_TOKEN` is missing. The call button will remain disabled without `NEXT_PUBLIC_VAPI_ASSISTANT_ID`.
 
 ## Learn More
 

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -4,7 +4,6 @@ import { isAuthenticated } from "@/lib/actions/auth.actions";
 
 const AuthLayout = async ({ children }: { children: ReactNode }) => {
   const isUserAuthenticated = await isAuthenticated();
-  console.log(isUserAuthenticated)
   if (isUserAuthenticated) redirect("/");
 
   return <div className="auth-layout">{children}</div>;

--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -6,7 +6,6 @@ import { isAuthenticated } from "@/lib/actions/auth.actions";
 
 const Layout = async ({ children }: { children: ReactNode }) => {
   const isUserAuthenticated = await isAuthenticated();
-  console.log(isUserAuthenticated)
   if (!isUserAuthenticated) redirect("/sign-in");
 
   return (

--- a/components/Agent.tsx
+++ b/components/Agent.tsx
@@ -31,10 +31,17 @@ const Agent = ({ userName }: AgentProps) => {
     const [messages, setMessages] = useState<string[]>([])
     const messagesEndRef = useRef<HTMLDivElement>(null)
 
+    const assistantId = process.env.NEXT_PUBLIC_VAPI_ASSISTANT_ID
+
     const startCall = async () => {
+        if (!assistantId) {
+            console.error('NEXT_PUBLIC_VAPI_ASSISTANT_ID is not set')
+            return
+        }
+
         try {
             setCallStatus(CallStatus.CONNECTING)
-            await vapi.start(process.env.NEXT_PUBLIC_VAPI_ASSISTANT_ID || undefined)
+            await vapi.start(assistantId)
         } catch (error) {
             console.error(error)
             setCallStatus(CallStatus.INACTIVE)
@@ -130,7 +137,7 @@ const Agent = ({ userName }: AgentProps) => {
             </div>
             <div className='w-full flex justify-center'>
                 {callStatus !== CallStatus.ACTIVE ? (
-                    <button onClick={startCall} className='relative'>
+                    <button onClick={startCall} className='relative' disabled={!assistantId}>
                         <span
                             className={cn(
                                 'absolute animate-ping rounded-full opacity-75',

--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 
 import FormField from "./FormField";
 import { signIn, signUp } from "@/lib/actions/auth.actions";
+import type { FirebaseError } from "firebase/app";
 
 const authFormSchema = (type: FormType) => {
   return z.object({
@@ -95,19 +96,24 @@ const AuthForm = ({ type }: { type: FormType }) => {
           toast.error(result?.message || "Sign in failed. Please try again.");
         }
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Auth error:", error);
-      
+
+      const firebaseError = error as FirebaseError;
+
       // Handle Firebase Auth errors
-      if (error.code === "auth/email-already-in-use") {
+      if (firebaseError.code === "auth/email-already-in-use") {
         toast.error("This email is already registered. Please sign in.");
-      } else if (error.code === "auth/weak-password") {
+      } else if (firebaseError.code === "auth/weak-password") {
         toast.error("Password should be at least 6 characters.");
-      } else if (error.code === "auth/invalid-email") {
+      } else if (firebaseError.code === "auth/invalid-email") {
         toast.error("Invalid email address.");
-      } else if (error.code === "auth/user-not-found") {
+      } else if (firebaseError.code === "auth/user-not-found") {
         toast.error("No account found with this email.");
-      } else if (error.code === "auth/wrong-password" || error.code === "auth/invalid-credential") {
+      } else if (
+        firebaseError.code === "auth/wrong-password" ||
+        firebaseError.code === "auth/invalid-credential"
+      ) {
         toast.error("Incorrect password. Please try again.");
       } else {
         toast.error("An error occurred. Please try again.");

--- a/lib/actions/auth.actions.ts
+++ b/lib/actions/auth.actions.ts
@@ -48,7 +48,7 @@ export async function signUp(params: SignUpParams) {
       success: true,
       message: "Account created successfully. Please sign in.",
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("Error creating user:", error);
 
     return {
@@ -84,7 +84,7 @@ export async function signIn(params: SignInParams) {
       success: true,
       message: "Signed in successfully",
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("Sign in error:", error);
 
     return {
@@ -121,7 +121,7 @@ export async function getCurrentUser(): Promise<User | null> {
       ...userRecord.data(),
       id: userRecord.id,
     } as User;
-  } catch (error) {
+  } catch {
     // Invalid or expired session
     return null;
   }


### PR DESCRIPTION
## Summary
- remove console logs from layout components
- use typed FirebaseError in auth form instead of `any`
- replace `any` in server auth actions and drop unused error var
- guard calls without `NEXT_PUBLIC_VAPI_ASSISTANT_ID` and disable the call button until configured
- document required Vapi assistant ID env var

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch `Mona Sans` from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_6896415b81bc83259b1b4a4db39148bc